### PR TITLE
NIP-46: Follow the latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ You can wait until a session is established by `await`-ing on `established` prop
 This promise resolves to an object that have session data (`session`) along with a handle to the remote signer (`signer`).
 **You should store this session data in somewhere** to resume the session later (e.g. after a browser reload).
 
-You can cancel listening a connection from the remote signer by calling `cancel` function in the return value.
-When you cancel, `established` is rejected with an error.
-
 ```ts
 import { Nip46RemoteSigner, type Nip46ClientMetadata } from 'nostr-signer-connector';
 
@@ -100,7 +97,7 @@ const client: Nip46ClientMetadata = {
     url: "https://example.com",
     description: "just a sample"
 };
-const { connectUri, established, cancel } = 
+const { connectUri, established } = 
     Nip46RemoteSigner.listenConnectionFromRemote(relayUrls, client);
 
 // show the connect URI to user

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -59,3 +59,5 @@ export class Deferred<T> {
 }
 
 export const delay = (durationMs: number) => new Promise((resolve) => setTimeout(resolve, durationMs));
+
+export const mergeOptionsWithDefaults = <T>(defaults: Required<T>, opts: T): Required<T> => ({ ...defaults, ...opts });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -36,6 +36,8 @@ export const parsePubkey = (pubkey: string): string | undefined => {
 
 export const currentUnixtimeSec = () => Math.floor(Date.now() / 1000);
 
+export const generateRandomString = () => Math.random().toString(32).substring(2, 8);
+
 export interface Deferred<T> {
   resolve(v: T | PromiseLike<T>): void;
   reject(e?: unknown): void;

--- a/src/nip46/relay_pool.ts
+++ b/src/nip46/relay_pool.ts
@@ -32,7 +32,7 @@ export class RxNostrRelayPool implements RelayPool {
   constructor(relayUrls: string[]) {
     this.#relayUrls = relayUrls;
 
-    const rxn = createRxNostr({ skipFetchNip11: true });
+    const rxn = createRxNostr({ skipFetchNip11: true, connectionStrategy: "lazy-keep" });
     rxn.setDefaultRelays(relayUrls);
 
     rxn.createConnectionStateObservable().subscribe(({ from: rurl, state }) => {

--- a/src/nip46/rpc.ts
+++ b/src/nip46/rpc.ts
@@ -23,7 +23,7 @@ const parseRpcResp = async (ev: NostrEvent, signer: NostrSigner): Promise<Nip46R
 
 type Nip46RpcSignatures = {
   connect: {
-    params: [pubkey: string, secret?: string, permissions?: string];
+    params: [remotePubkey: string, secret?: string, permissions?: string];
     result: string;
   };
   get_public_key: {

--- a/src/nip46/signer.test.ts
+++ b/src/nip46/signer.test.ts
@@ -8,13 +8,15 @@ const testPubkey = {
 
 describe("parseConnToken", () => {
   describe("should parse bunker:// token", () => {
-    test("pubkey only", () => {
-      const { remotePubkey, relayUrls, secretToken } = parseConnToken(`bunker://${testPubkey.npub}`);
+    test("minimal", () => {
+      const { remotePubkey, relayUrls, secretToken } = parseConnToken(
+        `bunker://${testPubkey.npub}?relay=wss%3A%2F%2Fyabu.me&relay=wss%3A%2F%2Fnrelay.c-stellar.net`,
+      );
       expect(remotePubkey).toBe(testPubkey.hex);
-      expect(relayUrls).toHaveLength(0);
+      expect(relayUrls).toEqual(["wss://yabu.me", "wss://nrelay.c-stellar.net"]);
       expect(secretToken).toBeUndefined();
     });
-    test("pubkey, relay URLs and secret token", () => {
+    test("with secret", () => {
       const { remotePubkey, relayUrls, secretToken } = parseConnToken(
         `bunker://${testPubkey.npub}?relay=wss%3A%2F%2Fyabu.me&relay=wss%3A%2F%2Fnrelay.c-stellar.net&secret=123456`,
       );
@@ -25,16 +27,21 @@ describe("parseConnToken", () => {
   });
 
   describe("should throw error when invalid connection token", () => {
-    test("URL token: invalid schema", () => {
+    test("invalid schema", () => {
       expect(() => {
         parseConnToken(
           `invalid://${testPubkey.npub}?relay=wss%3A%2F%2Fyabu.me&relay=wss%3A%2F%2Fnrelay.c-stellar.net&secret=123456`,
         );
       }).toThrowError();
     });
-    test("URL token: invalid pubkey", () => {
+    test("invalid pubkey", () => {
       expect(() => {
         parseConnToken("bunker://hoge");
+      }).toThrowError();
+    });
+    test("no relay URLs", () => {
+      expect(() => {
+        parseConnToken(`bunker://${testPubkey.npub}`);
       }).toThrowError();
     });
     test("legacy token format", () => {

--- a/src/nip46/signer.ts
+++ b/src/nip46/signer.ts
@@ -201,6 +201,7 @@ export class Nip46RemoteSigner implements NostrSigner, Disposable {
   public static listenConnectionFromRemote(
     relayUrls: string[],
     clientMetadata: Nip46ClientMetadata,
+    permissions: string[] = [],
     operationTimeoutMs = 15 * 1000,
   ): {
     connectUri: string;
@@ -217,7 +218,12 @@ export class Nip46RemoteSigner implements NostrSigner, Disposable {
     for (const rurl of relayUrls) {
       connUri.searchParams.append("relay", rurl);
     }
-    connUri.searchParams.set("metadata", JSON.stringify(clientMetadata));
+
+    const metaWithPerms = {
+      ...clientMetadata,
+      perms: permissions.length > 0 ? permissions.join(",") : undefined,
+    };
+    connUri.searchParams.set("metadata", JSON.stringify(metaWithPerms));
     connUri.searchParams.set("secret", connSecret);
 
     const relayPool = new RxNostrRelayPool(relayUrls);

--- a/src/nip46/signer.ts
+++ b/src/nip46/signer.ts
@@ -131,8 +131,7 @@ export class Nip46RemoteSigner implements NostrSigner, Disposable {
 
     // perform connection handshake
     try {
-      const localPubkey = await localSigner.getPublicKey();
-      const connParams: [string] = [localPubkey];
+      const connParams: [string] = [remotePubkey];
       if (secretToken !== undefined) {
         connParams.push(secretToken);
       }


### PR DESCRIPTION
- follow the latest spec of connection initiation flow with `nostrconnect:` URL
  - resolves #140
- add support for requesting permissions on `nostrconnect:` flow
  - resolves #141
- add auth challenge handling
  - resolves #142
- make relay URLs in connection tokens mandatory
  - resolves #147
- a lot of bug fixes
